### PR TITLE
Update KnowyourerrorMessages.rst

### DIFF
--- a/pip2/source/Debugging/KnowyourerrorMessages.rst
+++ b/pip2/source/Debugging/KnowyourerrorMessages.rst
@@ -10,7 +10,7 @@
 Know your error Messages
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Many problems in your program will lead to an error message.  For example as I was writing and testing this chapter of the book I wrote the following version of the example program in the previous section.
+Many problems in your program will lead to an error message.  For example, as I was writing and testing this chapter of the book I wrote the following version of the example program in the previous section:
 
 .. sourcecode:: python
 


### PR DESCRIPTION
In the sentence, "For example as I was writing and testing this chapter of the book I wrote the following version of the example program in the previous section." by adding a comma after "For example" and ended it in a colon.  This is proper grammar.
